### PR TITLE
Remove debug trace.

### DIFF
--- a/src/MonadicBang/Internal.hs
+++ b/src/MonadicBang/Internal.hs
@@ -41,8 +41,6 @@ import GHC.Types.Error
 import GHC.Utils.Monad (concatMapM, whenM)
 import Text.Printf
 
-import Debug.Trace
-
 import GHC.Utils.Logger
 
 import MonadicBang.Effect.Offer
@@ -116,7 +114,6 @@ spanToLoc = liftA2 MkLoc srcLocLine srcLocCol . realSrcSpanStart
 replaceBangs :: [CommandLineOption] -> ModSummary -> Handler Hsc ParsedResult
 replaceBangs cmdLineOpts _ (ParsedResult (HsParsedModule mod' files) msgs) = do
   options <- liftIO . (either throwIO pure =<<) . runThrow @ErrorCall $ parseOptions mod' cmdLineOpts
-  traceShow cmdLineOpts $ pure ()
   dflags <- getDynFlags
   (newErrors, mod'') <-
     runM .


### PR DESCRIPTION
I noticed a little stray `[]` when building my program

Maybe this could be replaced with some kind of logging if you prefer, but I figure it doesn’t need to be here in this form, anyhow

Also fyi there’s [`traceShowM`](https://hackage.haskell.org/package/base-4.18.0.0/docs/Debug-Trace.html#v:traceShowM) which is a little shorter than `traceShow` + `pure ()`