### PR TITLE
Run ci on main branch

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,5 +1,7 @@
 name: Run Tests
 on:
+  push:
+    branches: main
   pull_request:
     branches: main
 


### PR DESCRIPTION
This should be redundant, since PRs are set to be required to be rebased on main to be merged anyway, but provides some added peace of mind and more importantly lets us add a neat little status badge to the README.

Realistically it shouldn't require too many additional minutes.