### PR TITLE
Error writer in test suite

### DIFF
--- a/monadic-bang.cabal
+++ b/monadic-bang.cabal
@@ -122,7 +122,6 @@ test-suite monadic-bang-test
                       ghc-boot >= 9.4 && < 9.7,
                       ghc-paths ^>= 0.1.0.12,
                       transformers,
-                      exceptions ^>= 0.10,
                       monadic-bang
 
     ghc-options:      -Wall -Wcompat -plugin-package=monadic-bang

--- a/test/MonadicBang/Test.hs
+++ b/test/MonadicBang/Test.hs
@@ -1,13 +1,51 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LexicalNegation #-}
 {-# LANGUAGE MonadComprehensions #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Main (main) where
 
+import Prelude hiding ((<>))
+#if MIN_VERSION_ghc(9,6,0)
+#else
+import Control.Applicative (liftA2)
+#endif
+import Data.Foldable
+import Data.Traversable
+import System.IO
+
+import MonadicBang.Test.Utils
 import MonadicBang.Test.ShouldPass
 import MonadicBang.Test.ShouldFail
 
+import GHC.Utils.Outputable
+import GHC.Utils.Ppr (Mode(PageMode))
+import System.Exit (exitFailure)
+
 main :: IO ()
 main = do
-  shouldPass
-  shouldFail
+  (numFailures, numFailedSuites) <- liftA2 (,) sum (length . filter (> 0)) <$> for suites \suite -> do
+    failures <- runSuite suite
+    for_ failures \failure -> putSDoc stderr $ vcat [space, prettyFail failure]
+    pure $ length failures
+  if numFailures == 0
+    then putStrLn "All tests passed!"
+    else do
+      putSDoc stdout $
+        space $+$ plural' numFailures "test" <+> text "in" <+> int numFailedSuites <> char '/' <> plural' (length suites) "suite" <+> text "failed."
+      exitFailure
+  where
+    plural' :: Int -> String -> SDoc
+    plural' n (text -> s) = int n <+> case n of
+      1 -> s
+      _ -> s <> char 's'
+
+putSDoc :: Handle -> SDoc -> IO ()
+putSDoc = printSDocLn defaultSDocContext (PageMode True)
+
+suites :: [TestType]
+suites =
+  [ shouldPass
+  , shouldFail
+  ]

--- a/test/MonadicBang/Test/ShouldPass.hs
+++ b/test/MonadicBang/Test/ShouldPass.hs
@@ -16,6 +16,7 @@ import Control.Monad.Trans.State
 
 import MonadicBang.Test.Utils
 import MonadicBang.Test.Utils.QualifiedDo qualified as QualifiedDo
+import Control.Monad.IO.Class
 
 shouldPass :: Test
 shouldPass = do
@@ -39,7 +40,7 @@ shouldPass = do
   confusing
   qualifiedDo
 
-getA, getB, getC :: IO String
+getA, getB, getC :: MonadIO m => m String
 getA = pure "a"
 getB = pure "b"
 getC = pure "c"

--- a/test/MonadicBang/Test/Utils.hs
+++ b/test/MonadicBang/Test/Utils.hs
@@ -4,12 +4,17 @@
 #if MIN_VERSION_ghc(9,6,0)
 {-# LANGUAGE ScopedTypeVariables #-}
 #endif
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module MonadicBang.Test.Utils where
 
 import Control.Monad
 import Data.Foldable
 import Data.Function
+
+import Control.Monad.Trans.Writer.CPS
 
 import GHC.Stack
 
@@ -20,49 +25,76 @@ import GHC.Types.SourceError
 import GHC.Utils.Outputable hiding ((<>))
 
 import MonadicBang.Test.Utils.RunGhcParser
+import MonadicBang.Utils
+import Data.Monoid
 
--- TODO: This should use a Writer to collect all errors
-type Test = HasCallStack => IO ()
+data FailType
+  = forall a . Show a => IncorrectResult { expectedValue :: a, actualValue :: a }
+  | forall a . Outputable a => Didn'tFail { expectedFails :: [PsMessage], actualValue :: a }
+  | FailedIncorrectly { expectedFails :: [PsMessage], actualFails :: [GhcMessage] }
 
-assertEq :: (HasCallStack, Show a, Eq a) => a -> a -> IO ()
--- We don't care about seeing where the `error` call itself happens in the
--- call stack, so we freeze it
-assertEq expected actual = when (expected /= actual) $ withFrozenCallStack do
-  error $ "Expected " <> show expected <> ", but got " <> show actual
+data Fail = MkFail { error :: FailType, callStack :: CallStack }
+
+type TestType = WriterT (DList Fail) IO ()
+
+type Test = HasCallStack => TestType
+
+runSuite :: TestType -> IO [Fail]
+runSuite test = fromDList <$> execWriterT test
+
+prettyFail :: Fail -> SDoc
+prettyFail failure = vcat
+  [ case failure.error of
+      IncorrectResult{ expectedValue, actualValue } -> vcat
+        [ text "Expected: " <+> text (show expectedValue)
+        , text "but got:  " <+> text (show actualValue)
+        ]
+      Didn'tFail{ expectedFails } -> vcat
+        [ text "Expected failure with"
+        , nest 2 $ diagnosticsSDoc expectedFails
+        , text "but execution succeeded"
+        ]
+      FailedIncorrectly{ expectedFails, actualFails } -> vcat
+        [ text "Expected failure with"
+        , nest 2 $ diagnosticsSDoc expectedFails
+        , text "but execution failed with these errors instead:"
+        , nest 2 $ diagnosticsSDoc actualFails
+        ]
+  , text "at" <+> text (prettyCallStack failure.callStack)
+  ]
+  where
+    diagnosticsSDoc diags = vcat (map (vcat . unDecorated . diagMsg) diags)
+
+recordFail :: HasCallStack => FailType -> TestType
+recordFail err = tell . Endo . (:) $ MkFail err callStack
+
+assertEq :: (HasCallStack, Show a, Eq a) => a -> a -> TestType
+assertEq expected actual = when (expected /= actual) $
+  withFrozenCallStack $ recordFail $ IncorrectResult expected actual
 
 sdocEq :: SDoc -> SDoc -> Bool
 sdocEq = (==) `on` showSDocUnsafe
 
-assertFailWith :: (HasCallStack, Outputable a) => [PsMessage] -> Either SourceError a -> IO ()
+assertFailWith :: (HasCallStack, Outputable a) => [PsMessage] -> Either SourceError a -> TestType
 assertFailWith expected = \case
-  Right result -> withFrozenCallStack $ error . showSDocUnsafe $
-    text "\n    Expected failure with" $$
-    diagnosticsSDoc expected $$
-    text "    but execution succeeded with this result:" $$
-    ppr result
-  Left err -> unless sameErrors do
-    error . showSDocUnsafe $
-      text "\n    Expected failure with" $$
-      diagnosticsSDoc expected $$
-      text "    but execution failed with these errors instead:" $$
-      diagnosticsSDoc errMsgs
+  Right result -> withFrozenCallStack $ recordFail $ Didn'tFail expected result
+  Left err -> unless sameFails do
+    withFrozenCallStack $ recordFail $ FailedIncorrectly expected errMsgs
     where
       errMsgs = toList (srcErrorMessages err)
       toPsMessage = \case
         GhcPsMessage m -> Just m
         _ -> Nothing
       listEq eq xs ys = and $ zipWith eq xs ys
-      sameErrors = maybe False (((listEq . listEq) sdocEq `on` map (unDecorated . diagMsg)) expected) $ traverse toPsMessage errMsgs
-  where
-    diagnosticsSDoc diags = vcat (map (vcat . unDecorated . diagMsg) diags)
+      sameFails = maybe False (((listEq . listEq) sdocEq `on` map (unDecorated . diagMsg)) expected) $ traverse toPsMessage errMsgs
 
-    diagMsg :: forall a . Diagnostic a => a -> DecoratedSDoc
+diagMsg :: forall a . Diagnostic a => a -> DecoratedSDoc
 #if MIN_VERSION_ghc(9,6,0)
-    diagMsg = diagnosticMessage (defaultDiagnosticOpts @a)
+diagMsg = diagnosticMessage (defaultDiagnosticOpts @a)
 #else
-    diagMsg = diagnosticMessage
+diagMsg = diagnosticMessage
 #endif
 
-assertParseFailWith :: HasCallStack => [PsMessage] -> String -> IO ()
-assertParseFailWith expected source = withFrozenCallStack do
+assertParseFailWith :: HasCallStack => [PsMessage] -> String -> TestType
+assertParseFailWith expected source = withFrozenCallStack $
   assertFailWith expected . fmap pm_parsed_source =<< parseGhc source


### PR DESCRIPTION
Use a `Writer` to collect all errors in the test suite, rather than just reporting the first failure