### PR TITLE
Fix CPP condition for hoistMaybe

### DIFF
--- a/src/MonadicBang/Utils.hs
+++ b/src/MonadicBang/Utils.hs
@@ -24,9 +24,8 @@ fromDList = appEndo ?? []
 (??) :: Functor f => f (a -> b) -> a -> f b
 fs ?? x = ($ x) <$> fs
 
-#if MIN_VERSION_ghc(9,6,0)
+#if MIN_VERSION_transformers(0,6,0)
 #else
--- This is included in transformers 0.6, but that can't be used together with ghc 9.4
 {-# INLINE hoistMaybe #-}
 hoistMaybe :: Applicative m => Maybe a -> MaybeT m a
 hoistMaybe = MaybeT . pure


### PR DESCRIPTION
While it's probably true that ghc is needed iff ghc's version is < 9.6, it's more precise and seems more robust to take the version of the transformers package for the condition