### PR TITLE
Open GitHub issue on bump workflow failure

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -9,9 +9,38 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
     - uses: nomeata/haskell-bounds-bump-action@main
+    - if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const title = 'Dependency bump PR workflow failed';
+          const { data: issues } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'bump-failure',
+          });
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          if (issues.length > 0) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issues[0].number,
+              body: `Still failing: ${runUrl}`,
+            });
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: `The dependency bump workflow failed.\n\nSee: ${runUrl}`,
+              labels: ['bump-failure'],
+            });
+          }


### PR DESCRIPTION
## Summary
- GitHub silences email notifications for scheduled workflows on inactive repos, which means bump failures go unnoticed
- Added a failure step that creates a GitHub issue (labeled `bump-failure`) on first failure, and adds comments to the existing issue on subsequent failures
- Avoids duplicate issues by checking for an existing open issue with the `bump-failure` label

## Test plan
- [x] Merge and wait for next scheduled run (or trigger manually via workflow_dispatch) to verify the failure step works