### PR TITLE
Bump version to 0.2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for monadic-bang
 
+## 0.2.2.3 -- 2026-02-04
+
+* Added support for GHC 9.14
+
 ## 0.2.2.1 -- 2024-05-20
 
 * Only run plugin on modules that contain bangs

--- a/monadic-bang.cabal
+++ b/monadic-bang.cabal
@@ -14,7 +14,7 @@ name:               monadic-bang
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:            0.2.2.2
+version:            0.2.2.3
 
 -- A short (one-line) description of the package.
 synopsis:           GHC plugin to desugar ! into do-notation


### PR DESCRIPTION
## Summary
- Bump version from 0.2.2.2 to 0.2.2.3
- Update CHANGELOG for GHC 9.14 support